### PR TITLE
add module database and package_rate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 cli = { version = "0.1.0", path = "cli" }
-rocket = "0.5.0-rc.2"
+rocket = { version = "0.5.0-rc.2", features = ["json"] }
 tokio = { version = "1.25.0", features = ["macros"] }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -161,7 +161,6 @@ pub async fn rate(url: &str, token: &str) -> Option<GithubRepo> {
     let ghurl: String;
     if let Some(domain) = u.domain() {
         if domain == "www.npmjs.com" {
-            println!("here");
             // handle npm URLs
             let npm_url = url.replace(
                 "https://www.npmjs.com/package/",
@@ -186,7 +185,6 @@ pub async fn rate(url: &str, token: &str) -> Option<GithubRepo> {
             // Do not need to check if url contains git+, just do replace. That would take care of it
             let derefurl = giturl.replace(".git", "");
             ghurl = derefurl;
-            println!("{:?}", ghurl);
         } else if domain != "github.com" {
             return None;
         } else {

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -161,6 +161,7 @@ pub async fn rate(url: &str, token: &str) -> Option<GithubRepo> {
     let ghurl: String;
     if let Some(domain) = u.domain() {
         if domain == "www.npmjs.com" {
+            println!("here");
             // handle npm URLs
             let npm_url = url.replace(
                 "https://www.npmjs.com/package/",
@@ -173,18 +174,19 @@ pub async fn rate(url: &str, token: &str) -> Option<GithubRepo> {
             let root: Value = serde_json::from_str(&input).ok()?;
 
             // access element using .get()
-            let giturl: Option<&str> = root
+            let giturl: &str = root
                 .get("repository")
                 .and_then(|value| value.get("url"))
-                .and_then(|value| value.as_str());
+                .and_then(|value| value.as_str())?;
 
-            // dereference the url so we can use .replace() later
-            let derefurl = &giturl.as_deref()?;
+            // force scheme to https
+            let spl = giturl.split_once("://")?;
+            let giturl = "https://".to_owned() + spl.1;
 
             // Do not need to check if url contains git+, just do replace. That would take care of it
-            let derefurl = derefurl.replace("git+", "");
-            let derefurl = derefurl.replace(".git", "");
+            let derefurl = giturl.replace(".git", "");
             ghurl = derefurl;
+            println!("{:?}", ghurl);
         } else if domain != "github.com" {
             return None;
         } else {

--- a/src/api.rs
+++ b/src/api.rs
@@ -37,12 +37,14 @@ pub async fn package_rate(
     // get scores from metadata
     let scores = res.unwrap();
     let ret = PackageRating {
+        NetScore: scores.overall,
         BusFactor: scores.bus,
         Correctness: scores.correct,
         RampUp: scores.rampup,
         ResponsiveMaintainer: scores.responsive,
         LicenseScore: scores.license,
         GoodPinningPractice: scores.version,
+        GoodEngineeringProcess: scores.review,
     };
     (Status::Ok, Either::Left(Json(ret)))
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,3 +1,13 @@
+mod schema;
+
+use crate::database::ModuleDB;
+use schema::*;
+
+use rocket::http::Status;
+use rocket::response::status;
+use rocket::serde::json::Json;
+use rocket::Either;
+use rocket::State;
 //#[cfg(test)]
 //mod tests;
 
@@ -6,4 +16,39 @@
 #[get("/")]
 pub fn world() -> &'static str {
     "Hello, world!"
+}
+
+#[get("/test")]
+pub fn test() -> &'static str {
+    "Hello, test!"
+}
+
+#[get("/package/<id>/rate")]
+pub async fn package_rate(
+    id: String,
+    mod_db: &State<ModuleDB>,
+) -> (Status, Either<Json<PackageRating>, &'static str>) {
+    // get package metadata
+    let mod_r = mod_db.read().await;
+    let res = mod_r.get(&id);
+    if res.is_none() {
+        return (Status::NotFound, Either::Right("Package does not exist."));
+    }
+
+    // get scores from metadata
+    let scores = res.unwrap();
+    let ret = PackageRating {
+        BusFactor: scores.bus,
+        Correctness: scores.correct,
+        RampUp: scores.rampup,
+        ResponsiveMaintainer: scores.responsive,
+        LicenseScore: scores.license,
+        GoodPinningPractice: scores.version,
+    };
+    (Status::Ok, Either::Left(Json(ret)))
+}
+
+#[get("/package/<_>/rate")]
+pub async fn package_rate_bad() -> status::BadRequest<()> {
+    status::BadRequest::<()>(None)
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,7 +4,6 @@ use crate::database::ModuleDB;
 use schema::*;
 
 use rocket::http::Status;
-use rocket::response::status;
 use rocket::serde::json::Json;
 use rocket::Either;
 use rocket::State;
@@ -46,9 +45,4 @@ pub async fn package_rate(
         GoodPinningPractice: scores.version,
     };
     (Status::Ok, Either::Left(Json(ret)))
-}
-
-#[get("/package/<_>/rate")]
-pub async fn package_rate_bad() -> status::BadRequest<()> {
-    status::BadRequest::<()>(None)
 }

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -4,10 +4,12 @@ use rocket::serde::Serialize;
 #[derive(Serialize)]
 #[serde(crate = "rocket::serde")]
 pub struct PackageRating {
+    pub NetScore: f64,
     pub BusFactor: f64,
     pub Correctness: f64,
     pub RampUp: f64,
     pub ResponsiveMaintainer: f64,
     pub LicenseScore: f64,
     pub GoodPinningPractice: f64,
+    pub GoodEngineeringProcess: f64,
 }

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -1,0 +1,13 @@
+#![allow(non_snake_case)]
+use rocket::serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(crate = "rocket::serde")]
+pub struct PackageRating {
+    pub BusFactor: f64,
+    pub Correctness: f64,
+    pub RampUp: f64,
+    pub ResponsiveMaintainer: f64,
+    pub LicenseScore: f64,
+    pub GoodPinningPractice: f64,
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,41 @@
+use rocket::tokio::sync::RwLock;
+use std::{collections::HashMap, path::PathBuf};
+
+pub type ModuleDB = RwLock<HashMap<String, Module>>;
+
+// create empty ModuleDB
+// pub fn module_db() -> ModuleDB {
+//     RwLock::new(HashMap::new())
+// }
+pub fn module_db() -> ModuleDB {
+    let mut hm = HashMap::new();
+    hm.insert("minimist".to_string(), Module::new("minimist".to_string(), "https://www.npmjs.com/package/minimist".to_string()));
+    RwLock::new(hm)
+}
+
+#[derive(Default, Debug)]
+pub struct Module {
+    pub id: String,
+    pub url: String,
+    pub path: PathBuf,
+
+    pub overall: f64,
+    pub bus: f64,
+    pub correct: f64,
+    pub license: f64,
+    pub responsive: f64,
+    pub rampup: f64,
+    pub version: f64,
+    pub review: f64,
+}
+
+impl Module {
+    // initialize struct, should calculate score with url
+    fn new(id: String, url: String) -> Self {
+        Self {
+            id,
+            url,
+            ..Default::default()
+        }
+    }
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -7,9 +7,18 @@ pub type ModuleDB = RwLock<HashMap<String, Module>>;
 // pub fn module_db() -> ModuleDB {
 //     RwLock::new(HashMap::new())
 // }
-pub fn module_db() -> ModuleDB {
+// this one has a default entry
+pub async fn module_db() -> ModuleDB {
     let mut hm = HashMap::new();
-    hm.insert("minimist".to_string(), Module::new("minimist".to_string(), "https://www.npmjs.com/package/minimist".to_string()));
+    hm.insert(
+        "postcss".to_string(),
+        Module::new(
+            "postcss".to_string(),
+            "https://www.npmjs.com/package/postcss".to_string(),
+        )
+        .await
+        .unwrap(),
+    );
     RwLock::new(hm)
 }
 
@@ -30,12 +39,96 @@ pub struct Module {
 }
 
 impl Module {
-    // initialize struct, should calculate score with url
-    fn new(id: String, url: String) -> Self {
-        Self {
+    // initialize struct
+    // TODO: add path
+    async fn new(id: String, url: String) -> Option<Self> {
+        let scores = cli::rate(&url, env!("GITHUB_TOKEN")).await?;
+        Some(Self {
             id,
             url,
+
+            overall: scores.overall() as f64,
+            bus: scores.bus() as f64,
+            correct: scores.correct() as f64,
+            license: scores.license() as f64,
+            responsive: scores.responsive() as f64,
+            rampup: scores.rampup() as f64,
+            version: scores.version() as f64,
+            review: scores.review() as f64,
+
             ..Default::default()
-        }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // test cli crate
+    #[rocket::async_test]
+    async fn rate_not_url() {
+        assert!(cli::rate("not/a/url", env!("GITHUB_TOKEN")).await.is_none());
+    }
+
+    #[rocket::async_test]
+    async fn rate_bad_url() {
+        assert!(cli::rate("https://osu.ppy.sh", env!("GITHUB_TOKEN"))
+            .await
+            .is_none());
+    }
+
+    #[rocket::async_test]
+    async fn rate_github() {
+        assert!(
+            cli::rate("https://github.com/postcss/postcss", env!("GITHUB_TOKEN"))
+                .await
+                .is_some()
+        );
+    }
+
+    #[rocket::async_test]
+    async fn rate_npm_1() {
+        assert!(cli::rate(
+            "https://www.npmjs.com/package/postcss",
+            env!("GITHUB_TOKEN")
+        )
+        .await
+        .is_some());
+    }
+
+    #[rocket::async_test]
+    async fn rate_npm_2() {
+        assert!(cli::rate(
+            "https://www.npmjs.com/package/minimist",
+            env!("GITHUB_TOKEN")
+        )
+        .await
+        .is_some());
+    }
+
+    // test Module
+    #[rocket::async_test]
+    async fn module_new() {
+        let res = Module::new(
+            "postcss".to_string(),
+            "https://www.npmjs.com/package/postcss".to_string(),
+        );
+    }
+
+    // test ModuleDB
+    #[rocket::async_test]
+    async fn module_db() {
+        let mdb: ModuleDB = RwLock::new(HashMap::new());
+        mdb.write()
+            .await
+            .insert("1".to_string(), Default::default());
+
+        // can have multiple readers
+        let r1 = mdb.read().await;
+        let r2 = mdb.read().await;
+        assert!(r1.get("1").is_some());
+        assert!(r2.get("2").is_none());
+        assert!(r1.get("3").is_none());
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -24,10 +24,14 @@ pub async fn module_db() -> ModuleDB {
 
 #[derive(Default, Debug)]
 pub struct Module {
+    // id of module
     pub id: String,
+    // url to webpage for module
     pub url: String,
+    // file storing contents of module
     pub path: PathBuf,
 
+    // module scores
     pub overall: f64,
     pub bus: f64,
     pub correct: f64,
@@ -113,7 +117,19 @@ mod tests {
         let res = Module::new(
             "postcss".to_string(),
             "https://www.npmjs.com/package/postcss".to_string(),
-        );
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(res.id, "postcss");
+        assert!(res.responsive >= 0.0 && res.responsive <= 1.0);
+    }
+
+    #[rocket::async_test]
+    async fn module_new_bad() {
+        let res = Module::new("no".to_string(), "not a url".to_string()).await;
+
+        assert!(res.is_none());
     }
 
     // test ModuleDB

--- a/src/database.rs
+++ b/src/database.rs
@@ -7,6 +7,7 @@ pub type ModuleDB = RwLock<HashMap<String, Module>>;
 // pub fn module_db() -> ModuleDB {
 //     RwLock::new(HashMap::new())
 // }
+//
 // this one has a default entry
 pub async fn module_db() -> ModuleDB {
     let mut hm = HashMap::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,15 @@
 mod api;
-use api::*;
+mod database;
+
 #[macro_use]
 extern crate rocket;
+
+use api::*;
 
 //#[cfg(test)]
 //mod tests;
 
 #[launch]
 fn rocket() -> _ {
-    rocket::build().mount("/", routes![world])
+    rocket::build().mount("/", routes![world, test, package_rate, package_rate_bad]).manage(database::module_db())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,6 @@ use api::*;
 //mod tests;
 
 #[launch]
-fn rocket() -> _ {
-    rocket::build().mount("/", routes![world, test, package_rate, package_rate_bad]).manage(database::module_db())
+async fn rocket() -> _ {
+    rocket::build().mount("/", routes![world, test, package_rate]).manage(database::module_db().await)
 }


### PR DESCRIPTION
Fix cli parsing npm URLs. Turns out it is also possible to get this type of URL from the npmjs registry `"git://github.com/minimistjs/minimist.git"` and the possibility isn't covered by the old code.

Add `Module` and `ModuleDB`, and implemented package rating to demonstrate how to use it.

Rating the packages require the `$GITHUB_TOKEN` environment variable.
The path that stores the module is not yet implemented.

Run the server, then go to http://127.0.0.1:8000/package/postcss/rate to see the return value.