### PR TITLE
Add api byregex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ cli = { version = "0.1.0", path = "cli" }
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
 tokio = { version = "1.25.0", features = ["macros"] }
 base64 = "0.21.0"
+regex = "1.7.3"
+zip = "0.6.4"

--- a/src/api/schema.rs
+++ b/src/api/schema.rs
@@ -46,6 +46,13 @@ pub struct PackageQuery {
     pub Name: String,
 }
 
+#[derive(Deserialize)]
+#[serde(crate = "rocket::serde")]
+pub struct PackageRegEx {
+    pub RegEx: String,
+}
+
+
 #[derive(Serialize)]
 #[serde(crate = "rocket::serde")]
 pub struct Package {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,6 @@ async fn rocket() -> _ {
                 package_by_regex_get,
             ],
         )
-        .register("/packages", catchers![packages_list_422])
+        .register("/", catchers![redirect_422_to_400])
         .manage(database::module_db().await)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ async fn rocket() -> _ {
                 package_rate,
                 package_by_name_get,
                 package_by_name_delete,
+                package_by_regex_get,
             ],
         )
         .register("/packages", catchers![packages_list_422])


### PR DESCRIPTION
Add `package_by_regex_get()`, I assume the readme is named `README.md` and at the root of the zip file.

Change the 422 catcher (mismatching json) so it applies to all 422 error (instead of only 422 error on `/packages`).